### PR TITLE
Feat: Add tagPattern extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+.gradle
+.idea
+build

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Example:
     * [Additional Release Info](#additional-release-info)
     * [Change Description](#change-description)
     * [Changes Limit](#changes-limit)
+    * [Define Tag Pattern](#define-tag-pattern)
 
 ## How to Use
 
@@ -177,3 +178,23 @@ releasePaperwork {
     maxChangesPerRelease.set(50)
 }
 ```
+
+### Define Tag Pattern
+
+There is a specific case where we want created tag name to be customized. It can be done by set the `tagPattern` as below:
+
+```
+releasePaperwork {
+   tagPattern.set("v%s")
+}
+```
+
+Which will create a tag with this format:
+
+```v1.0.0```
+
+Do remember that the character `%s` must be provided as the place for the version. If `tagPattern` does not defined, default pattern
+will be `release-%s` which will create a tag with this format:
+
+```release-1.0.0```
+

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/release/paperwork/GradleReleasePaperworkPlugin.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/release/paperwork/GradleReleasePaperworkPlugin.kt
@@ -351,8 +351,8 @@ class GradleReleasePaperworkPlugin : Plugin<Project> {
             project.logger.lifecycle("committing file $pathToCommit")
             git.add().addFilepattern(pathToCommit).call()
         }
-         val tagPrefix = getTagPrefix(extension)
-        return git.commit().setMessage(String.format(tagPrefix, newVersion)).call()
+         val tagPattern = getTagPattern(extension)
+        return git.commit().setMessage(String.format(tagPattern, newVersion)).call()
     }
 
     private fun createTag(
@@ -362,7 +362,7 @@ class GradleReleasePaperworkPlugin : Plugin<Project> {
         commitId: RevCommit
     ) {
         val git = Git.open(project.rootDir)
-        val tagName = String.format(getTagPrefix(extension), newVersion)
+        val tagName = String.format(getTagPattern(extension), newVersion)
         project.logger.lifecycle("creating git tag $tagName")
         git
             .tag()
@@ -372,13 +372,13 @@ class GradleReleasePaperworkPlugin : Plugin<Project> {
             .call()
     }
 
-    private fun getTagPrefix(extension: GradleReleasePaperworkPluginExtension) =
-        if (extension.tagPrefix.isPresent) "${extension.tagPrefix.get()}%s"
+    private fun getTagPattern(extension: GradleReleasePaperworkPluginExtension) =
+        if (extension.tagPattern.isPresent) extension.tagPattern.get()
         else DEFAULT_RELEASE_COMMIT_MESSAGE_PATTERN
 
     private fun getReleaseCommitRegex(extension: GradleReleasePaperworkPluginExtension): Regex {
-        val prefix = getTagPrefix(extension)
-        return prefix.replace("%s", "\\S+").toRegex()
+        val pattern = getTagPattern(extension)
+        return pattern.replace("%s", "\\S+").toRegex()
     }
 
     companion object {

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/release/paperwork/GradleReleasePaperworkPlugin.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/release/paperwork/GradleReleasePaperworkPlugin.kt
@@ -55,9 +55,10 @@ class GradleReleasePaperworkPlugin : Plugin<Project> {
                 val commit = commitChanges(
                     project = project,
                     newVersion = versionToRelease,
+                    extension = extension,
                     changedFiles = arrayOf(releaseNotesFile, getProjectVersionFile(project, extension))
                 )
-                createTag(versionToRelease, project, commit)
+                createTag(versionToRelease, project, extension, commit)
             }
         }
     }
@@ -241,8 +242,9 @@ class GradleReleasePaperworkPlugin : Plugin<Project> {
         val log = Git.open(project.rootDir).log().call()
         val result = mutableListOf<String>()
         val maxChanges = getMaxChangesPerRelease(extension)
+        val releaseCommitRegex = getReleaseCommitRegex(extension)
         for (commit in log) {
-            if (RELEASE_COMMIT_REGEX.matches(commit.shortMessage)) {
+            if (releaseCommitRegex.matches(commit.shortMessage)) {
                 // skip release commit
                 continue
             }
@@ -337,19 +339,30 @@ class GradleReleasePaperworkPlugin : Plugin<Project> {
         projectVersionFile.writeText(newContent)
     }
 
-    private fun commitChanges(project: Project, newVersion: String, vararg changedFiles: File): RevCommit {
+    private fun commitChanges(
+        project: Project,
+        newVersion: String,
+        extension: GradleReleasePaperworkPluginExtension,
+        vararg changedFiles: File,
+    ): RevCommit {
         val git = Git.open(project.rootDir)
         for (file in changedFiles) {
             val pathToCommit = project.rootDir.toPath().relativize(file.toPath()).toString()
             project.logger.lifecycle("committing file $pathToCommit")
             git.add().addFilepattern(pathToCommit).call()
         }
-        return git.commit().setMessage(String.format(RELEASE_COMMIT_MESSAGE_PATTERN, newVersion)).call()
+         val tagPrefix = getTagPrefix(extension)
+        return git.commit().setMessage(String.format(tagPrefix, newVersion)).call()
     }
 
-    private fun createTag(newVersion: String, project: Project, commitId: RevCommit) {
+    private fun createTag(
+        newVersion: String,
+        project: Project,
+        extension: GradleReleasePaperworkPluginExtension,
+        commitId: RevCommit
+    ) {
         val git = Git.open(project.rootDir)
-        val tagName = String.format(RELEASE_COMMIT_MESSAGE_PATTERN, newVersion)
+        val tagName = String.format(getTagPrefix(extension), newVersion)
         project.logger.lifecycle("creating git tag $tagName")
         git
             .tag()
@@ -359,15 +372,23 @@ class GradleReleasePaperworkPlugin : Plugin<Project> {
             .call()
     }
 
+    private fun getTagPrefix(extension: GradleReleasePaperworkPluginExtension) =
+        if (extension.tagPrefix.isPresent) "${extension.tagPrefix.get()}%s"
+        else DEFAULT_RELEASE_COMMIT_MESSAGE_PATTERN
+
+    private fun getReleaseCommitRegex(extension: GradleReleasePaperworkPluginExtension): Regex {
+        val prefix = getTagPrefix(extension)
+        return prefix.replace("%s", "\\S+").toRegex()
+    }
+
     companion object {
         val DEFAULT_PROJECT_VERSION_REGEX = """version\s*=\s*['"]([^'"]+)""".toRegex()
         const val DEFAULT_RELEASE_NOTES_FILE = "RELEASE_NOTES.md"
-        const val RELEASE_COMMIT_MESSAGE_PATTERN = "release-%s"
-        val RELEASE_COMMIT_REGEX = RELEASE_COMMIT_MESSAGE_PATTERN.replace("%s", "\\S+").toRegex()
+        const val DEFAULT_RELEASE_COMMIT_MESSAGE_PATTERN = "release-%s"
         const val RELEASE_DESCRIPTION_FORMAT = "v<version> released on <date><additional-release-description>"
         const val COMMIT_DESCRIPTION_FORMAT = "  * <commit-hash> <commit-description>"
         val COMMIT_DESCRIPTION_SUFFIX_REGEX = """\s+\*\s+""".toRegex()
-        val DATE_SYSTEM_PROPERTY_NAME = "paperwork.release.date"
+        const val DATE_SYSTEM_PROPERTY_NAME = "paperwork.release.date"
         val ZONE_UTC = ZoneId.of("UTC")
         private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("dd MMM yyyy z")
         private const val DEFAULT_MAX_CHANGES_PER_RELEASE = 20

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/release/paperwork/GradleReleasePaperworkPluginExtension.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/release/paperwork/GradleReleasePaperworkPluginExtension.kt
@@ -15,4 +15,6 @@ interface GradleReleasePaperworkPluginExtension {
     val changeDescription: Property<(String) -> String?>
 
     val maxChangesPerRelease: Property<Int>
+
+    val tagPrefix: Property<String>
 }

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/release/paperwork/GradleReleasePaperworkPluginExtension.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/release/paperwork/GradleReleasePaperworkPluginExtension.kt
@@ -16,5 +16,5 @@ interface GradleReleasePaperworkPluginExtension {
 
     val maxChangesPerRelease: Property<Int>
 
-    val tagPrefix: Property<String>
+    val tagPattern: Property<String>
 }

--- a/src/test/kotlin/tech/harmonysoft/oss/gradle/release/paperwork/GradleReleasePaperworkPluginTest.kt
+++ b/src/test/kotlin/tech/harmonysoft/oss/gradle/release/paperwork/GradleReleasePaperworkPluginTest.kt
@@ -486,7 +486,28 @@ internal class GradleReleasePaperworkPluginTest {
         """.trimIndent())
         runBuild()
 
-        val expected = String.format(GradleReleasePaperworkPlugin.RELEASE_COMMIT_MESSAGE_PATTERN, version)
+        val expected = String.format(GradleReleasePaperworkPlugin.DEFAULT_RELEASE_COMMIT_MESSAGE_PATTERN, version)
+        val tag = git.tagList().call().find {
+            val actual = it.name.substring("refs/tags/".length)
+            actual == expected
+        }
+        assertThat(tag).isNotNull
+    }
+
+    @Test
+    fun `when tagPrefix is defined then tag created will be using that`() {
+        val version = "1.0.0"
+        val prefix = "v"
+        gradleFile.appendText("""
+            version = "$version"
+            
+            releasePaperwork {
+                tagPrefix.set("$prefix")
+            }
+        """.trimIndent())
+        runBuild()
+
+        val expected = "$prefix$version"
         val tag = git.tagList().call().find {
             val actual = it.name.substring("refs/tags/".length)
             actual == expected


### PR DESCRIPTION
# Description

Add extension `tagPrefix` for customizing tag name. Will use prefix `release-` if `tagPrefix` is not defined.

# Usage

Given current version is `1.0.0`.

```
releasePaperwork {
    tagPattern.set("v%s")
}
```

Will create tag with name `v1.0.0`
